### PR TITLE
ensure log messages are in BST (GMT+1) for the summer. done this way …

### DIFF
--- a/src/main/resources/log4j.xml
+++ b/src/main/resources/log4j.xml
@@ -12,8 +12,8 @@
                 <!-- layout is configurable - can display thread id, class name, method
                         name, line number, the message etc -->
 
-                <layout class="org.apache.log4j.PatternLayout">
-                        <param name="ConversionPattern" value="%d{ISO8601}|%p|thread:%t|userId:%X{userId},statUnitId:%X{statUnitId},exerciseSid:%X{exerciseSid}|%m|%l%n" />
+                <layout class="org.apache.log4j.EnhancedPatternLayout">
+                        <param name="ConversionPattern" value="%d{ISO8601}{GMT+1}|%p|thread:%t|userId:%X{userId},statUnitId:%X{statUnitId},exerciseSid:%X{exerciseSid}|%m|%l%n" />
                 </layout>
         </appender>
 
@@ -22,13 +22,13 @@
 
         <appender name="FILE" class="org.apache.log4j.DailyRollingFileAppender">
                 <!-- defines the name of the log file produced -->
-                <param name="file" value="logs/perkin.log" />
+                <param name="file" value="logs/sdx-collect.log" />
                 <param name="datePattern" value="'.'yyyy-MM" />
                 <param name="append" value="true" />
 
                 <!-- defines the format of each log message -->
-                <layout class="org.apache.log4j.PatternLayout">
-                        <param name="ConversionPattern" value="%d{ISO8601}|%p|thread:%t|userId:%X{userId},statUnitId:%X{statUnitId},exerciseSid:%X{exerciseSid}|%m|%l%n" />
+                <layout class="org.apache.log4j.EnhancedPatternLayout">
+                        <param name="ConversionPattern" value="%d{ISO8601}{GMT+1}|%p|thread:%t|userId:%X{userId},statUnitId:%X{statUnitId},exerciseSid:%X{exerciseSid}|%m|%l%n" />
                 </layout>
         </appender>
 

--- a/src/test/resources/log4j.xml
+++ b/src/test/resources/log4j.xml
@@ -12,8 +12,8 @@
                 <!-- layout is configurable - can display thread id, class name, method
                         name, line number, the message etc -->
 
-                <layout class="org.apache.log4j.PatternLayout">
-                        <param name="ConversionPattern" value="%d{ISO8601}|%p|thread:%t|%m|%l%n" />
+                <layout class="org.apache.log4j.EnhancedPatternLayout">
+                        <param name="ConversionPattern" value="%d{ISO8601}{GMT+1}|%p|thread:%t|%m|%l%n" />
                 </layout>
         </appender>
 
@@ -27,8 +27,8 @@
                 <param name="append" value="true" />
 
                 <!-- defines the format of each log message -->
-                <layout class="org.apache.log4j.PatternLayout">
-                        <param name="ConversionPattern" value="%d{ISO8601}|%p|thread:%t|%m|%l%n" />
+                <layout class="org.apache.log4j.EnhancedPatternLayout">
+                        <param name="ConversionPattern" value="%d{ISO8601}{GMT+1}|%p|thread:%t|%m|%l%n" />
                 </layout>
         </appender>
 


### PR DESCRIPTION
…so will work for cloud foundry as well as docker

to test:
  run the maven build - should see test output as GMT + 1 hour (which is of course BST)
  can change the log4j.xml to GMT+2 to see an hour ahead of current time - to show the change works

who can test:
  anyone but david gunthorpe