### PR TITLE
add WRITE_BATCH_HEADER to env.properties

### DIFF
--- a/src/main/resources/env.properties
+++ b/src/main/resources/env.properties
@@ -44,3 +44,7 @@ NO_SSL_VERIFICATION=false
 # we are ftping from perkin instead
 #publish.host=http://pootle:8080/
 #publish.path=/publish
+
+# Batch header
+WRITE_BATCH_HEADER=true
+


### PR DESCRIPTION
so it can be overriden

to test:
  set jenkins value to false for WRITE_BATCH_HEADER, check logs that value has been set correctly to false

who can test:
  anyone but david gunthorpe