### PR TITLE
Make queue durable in queue_declare

### DIFF
--- a/app/async_consumer.py
+++ b/app/async_consumer.py
@@ -22,6 +22,7 @@ class AsyncConsumer(object):
     """
     EXCHANGE = 'message'
     EXCHANGE_TYPE = 'topic'
+    DURABLE_QUEUE = True
     QUEUE = settings.RABBIT_QUEUE
 
     def __init__(self):
@@ -186,7 +187,7 @@ class AsyncConsumer(object):
 
         """
         logger.info('Declaring queue', name=queue_name)
-        self._channel.queue_declare(self.on_queue_declareok, queue_name)
+        self._channel.queue_declare(self.on_queue_declareok, queue_name, durable=self.DURABLE_QUEUE)
 
     def on_queue_declareok(self, method_frame):
         """Method invoked by pika when the Queue.Declare RPC call made in


### PR DESCRIPTION
**Changes**
A recent eQ change has been to make the eQ queue durable, which also needs to be declared on the client side. This pull request adds this setting to the `queue_declare` call.

**How to test**
- Clean sdx-compose build with durable-queue branches for sdx-collect, sdx-console and sdx-bdd
- Run some surveys through the console
- Run sdx-bdd 
- Check the queue is marked as durable in the RabbitMQ UI

**Who can test**
Anyone but @ajmaddaford