### PR TITLE
Replace odd spaces with real spaces in mock receipt template

### DIFF
--- a/app/templates/receipt.xml.tmpl
+++ b/app/templates/receipt.xml.tmpl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <receipt xmlns="http://ns.ons.gov.uk/namespaces/resources/receipt">
-  <receipt_type>Completed</receipt_type>
-  <respondent_id>{{survey.metadata.user_id}}</respondent_id>
+  <receipt_type>Completed</receipt_type>
+  <respondent_id>{{survey.metadata.user_id}}</respondent_id>
   {%- if survey.tx_id %}
   <tx_id>{{survey.tx_id}}</tx_id>
   {%- endif %}

--- a/tests/test_receipt.py
+++ b/tests/test_receipt.py
@@ -11,7 +11,7 @@ def get_file_as_string(filename):
     f = open(filename)
     contents = f.read()
     f.close()
-    return contents
+    return contents.rstrip("\n")
 
 
 class TestReceipt(unittest.TestCase):

--- a/tests/xml/receipt_no_txid.xml
+++ b/tests/xml/receipt_no_txid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <receipt xmlns="http://ns.ons.gov.uk/namespaces/resources/receipt">
-  <receipt_type>Completed</receipt_type>
-  <respondent_id>789473423</respondent_id>
+  <receipt_type>Completed</receipt_type>
+  <respondent_id>789473423</respondent_id>
 </receipt>

--- a/tests/xml/receipt_txid.xml
+++ b/tests/xml/receipt_txid.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <receipt xmlns="http://ns.ons.gov.uk/namespaces/resources/receipt">
-  <receipt_type>Completed</receipt_type>
-  <respondent_id>789473423</respondent_id>
+  <receipt_type>Completed</receipt_type>
+  <respondent_id>789473423</respondent_id>
   <tx_id>0f534ffc-9442-414c-b39f-a756b4adc6cb</tx_id>
 </receipt>


### PR DESCRIPTION
The spaces before `<receipt_type>` and `<respondent_id>` weren't real spaces (each space was a byte sequence of 342 200 202). This commit replaces them with real spaces.