### PR TITLE
Fix receipt service call

### DIFF
--- a/app/receipt.py
+++ b/app/receipt.py
@@ -10,9 +10,24 @@ env = Environment(loader=FileSystemLoader('%s/templates/' % os.path.dirname(__fi
 logger = wrap_logger(logging.getLogger(__name__))
 
 
+def get_statistical_unit_id(ru_ref):
+    if ru_ref is None:
+        return ''
+
+    length = len(ru_ref)
+    if length < 12:
+        return ru_ref
+
+    if length == 12 and ru_ref[-1:].isalpha():
+        return ru_ref[0:11]
+
+    return ru_ref
+
+
 def get_receipt_endpoint(decrypted_json):
     try:
-        statistical_unit_id = decrypted_json['metadata']['ru_ref']
+        ru_ref = decrypted_json['metadata']['ru_ref']
+        statistical_unit_id = get_statistical_unit_id(ru_ref)
         exercise_sid = decrypted_json['collection']['exercise_sid']
     except KeyError as e:
         logger.error("Unable to get required data from json", exception=repr(e))

--- a/app/receipt.py
+++ b/app/receipt.py
@@ -40,8 +40,5 @@ def get_receipt_xml(decrypted_json):
 
 def get_receipt_headers():
     headers = {}
-    auth = settings.RECEIPT_USER + ":" + settings.RECEIPT_PASS
-    encoded = base64.b64encode(bytes(auth, 'utf-8'))
-    headers['Authorization'] = "Basic " + str(encoded)
     headers['Content-Type'] = "application/vnd.collections+xml"
     return headers

--- a/app/receipt.py
+++ b/app/receipt.py
@@ -1,7 +1,6 @@
 from app import settings
 import logging
 from structlog import wrap_logger
-import base64
 import os
 from jinja2 import Environment, FileSystemLoader
 

--- a/app/response_processor.py
+++ b/app/response_processor.py
@@ -75,20 +75,20 @@ class ResponseProcessor:
 
         headers = receipt.get_receipt_headers()
 
-        response = self.remote_call(endpoint, data=xml.encode("utf-8"), headers=headers, verify=False)
+        response = self.remote_call(endpoint, data=xml.encode("utf-8"), headers=headers, verify=False, auth=(settings.RECEIPT_USER, settings.RECEIPT_PASS))
         return self.response_ok(response)
 
-    def remote_call(self, request_url, json=None, data=None, headers=None, verify=True):
+    def remote_call(self, request_url, json=None, data=None, headers=None, verify=True, auth=None):
         try:
             self.logger.info("Calling service", request_url=request_url)
             r = None
 
             if json:
-                r = session.post(request_url, json=json, headers=headers, verify=verify)
+                r = session.post(request_url, json=json, headers=headers, verify=verify, auth=auth)
             elif data:
-                r = session.post(request_url, data=data, headers=headers, verify=verify)
+                r = session.post(request_url, data=data, headers=headers, verify=verify, auth=auth)
             else:
-                r = session.get(request_url, headers=headers, verify=verify)
+                r = session.get(request_url, headers=headers, verify=verify, auth=auth)
 
             return r
 

--- a/app/response_processor.py
+++ b/app/response_processor.py
@@ -75,20 +75,20 @@ class ResponseProcessor:
 
         headers = receipt.get_receipt_headers()
 
-        response = self.remote_call(endpoint, data=xml.encode("utf-8"), headers=headers)
+        response = self.remote_call(endpoint, data=xml.encode("utf-8"), headers=headers, verify=False)
         return self.response_ok(response)
 
-    def remote_call(self, request_url, json=None, data=None, headers=None):
+    def remote_call(self, request_url, json=None, data=None, headers=None, verify=True):
         try:
             self.logger.info("Calling service", request_url=request_url)
             r = None
 
             if json:
-                r = session.post(request_url, json=json, headers=headers)
+                r = session.post(request_url, json=json, headers=headers, verify=verify)
             elif data:
-                r = session.post(request_url, data=data, headers=headers)
+                r = session.post(request_url, data=data, headers=headers, verify=verify)
             else:
-                r = session.get(request_url, headers=headers)
+                r = session.get(request_url, headers=headers, verify=verify)
 
             return r
 

--- a/tests/test_receipt.py
+++ b/tests/test_receipt.py
@@ -15,11 +15,34 @@ def get_file_as_string(filename):
 
 
 class TestReceipt(unittest.TestCase):
+    def test_get_statistical_unit_id_no_ru_ref(self):
+        statistical_unit_id = receipt.get_statistical_unit_id('')
+        self.assertEqual(statistical_unit_id, '')
+
+    def test_get_statistical_unit_id_11_character_ru_ref(self):
+        ru_ref = '12345678901'
+        statistical_unit_id = receipt.get_statistical_unit_id(ru_ref)
+        self.assertEqual(statistical_unit_id, ru_ref)
+
+    def test_get_statistical_unit_id_12_character_ru_ref_ending_alpha(self):
+        ru_ref = '12345678901A'
+        statistical_unit_id = receipt.get_statistical_unit_id(ru_ref)
+        self.assertEqual(statistical_unit_id, '12345678901')
+
+    def test_get_statistical_unit_id_12_character_ru_ref_ending_non_alpha(self):
+        ru_ref = '123456789012'
+        statistical_unit_id = receipt.get_statistical_unit_id(ru_ref)
+        self.assertEqual(statistical_unit_id, '123456789012')
+
+    def test_get_statistical_unit_id_14_character_ru_ref(self):
+        ru_ref = '12345678901234'
+        statistical_unit_id = receipt.get_statistical_unit_id(ru_ref)
+        self.assertEqual(statistical_unit_id, ru_ref)
 
     def test_receipt_endpoint_valid_json(self):
         decrypted_json = json.loads(valid_decrypted)
         endpoint = receipt.get_receipt_endpoint(decrypted_json)
-        expected = "http://sdx-mock-receipt:5000/reportingunits/12345678901A/collectionexercises/hfjdskf/receipts"
+        expected = "http://sdx-mock-receipt:5000/reportingunits/12345678901/collectionexercises/hfjdskf/receipts"
 
         self.assertEqual(endpoint, expected)
 

--- a/tests/test_receipt.py
+++ b/tests/test_receipt.py
@@ -32,7 +32,6 @@ class TestReceipt(unittest.TestCase):
     def test_get_receipt_headers(self):
         headers = receipt.get_receipt_headers()
 
-        self.assertTrue("Basic " in headers['Authorization'])
         self.assertEqual(headers['Content-Type'], "application/vnd.collections+xml")
 
     def test_render_xml_valid_json_txid(self):


### PR DESCRIPTION
**Changes**
- Fix statistical unit id in receipt service URL
- Fix basic auth - now uses Python requests library built in auth method rather than constructing the auth header manually
- Turn off SSL certificate verification for receipt service call to workaround issue with the receipt service SSL certificate

**How to test**
- Run the sdx-compose setup
- Check out the mock-auth branch for the sdx-mock-receipt repo
- Check that receipt service calls fail with 401 authentication error
- Check out the add-receipt-service-auth branch for the sdx-compose repo
- Check that receipt service calls succeed with a 201 status

**Who can test**
Anyone but @ajmaddaford