### PR TITLE
Use dead letter queue and a count to provide retry functionality

### DIFF
--- a/app/async_consumer.py
+++ b/app/async_consumer.py
@@ -20,7 +20,7 @@ class AsyncConsumer(object):
     commands that were issued and that should surface in the output as well.
 
     """
-    EXCHANGE = 'message'
+    EXCHANGE = settings.RABBIT_EXCHANGE
     EXCHANGE_TYPE = 'topic'
     DURABLE_QUEUE = True
     QUEUE = settings.RABBIT_QUEUE
@@ -232,6 +232,16 @@ class AsyncConsumer(object):
         """
         logger.info('Acknowledging message', delivery_tag=delivery_tag, **kwargs)
         self._channel.basic_ack(delivery_tag)
+
+    def reject_message(self, delivery_tag, **kwargs):
+        """Reject the message delivery from RabbitMQ by sending a
+        Basic.Reject RPC method for the delivery tag.
+
+        :param int delivery_tag: The delivery tag from the Basic.Deliver frame
+
+        """
+        logger.info('Rejecting message', delivery_tag=delivery_tag, **kwargs)
+        self._channel.basic_reject(delivery_tag, requeue=False)
 
     def on_message(self, unused_channel, basic_deliver, properties, body):
         """Invoked by pika when a message is delivered from RabbitMQ. The

--- a/app/consumer.py
+++ b/app/consumer.py
@@ -37,13 +37,14 @@ class Consumer(AsyncConsumer):
         processor = ResponseProcessor(logger)
 
         try:
-            processed_ok = processor.process(body.decode("utf-8"))
+            message = body.decode("utf-8")
+            processed_ok = processor.process(message)
 
             if processed_ok:
                 self.acknowledge_message(basic_deliver.delivery_tag, tx_id=processor.tx_id)
             else:
                 if delivery_count == settings.QUEUE_MAX_MESSAGE_DELIVERIES:
-                    logger.error("Reached maximum number of retries", tx_id=processor.tx_id, delivery_count=delivery_count)
+                    logger.error("Reached maximum number of retries", tx_id=processor.tx_id, delivery_count=delivery_count, message=message)
                     self.reject_message(basic_deliver.delivery_tag, tx_id=processor.tx_id)
                 else:
                     if publish_to_retry_queue(body, delivery_count):

--- a/app/consumer.py
+++ b/app/consumer.py
@@ -2,13 +2,37 @@ import logging
 from structlog import wrap_logger
 from app.async_consumer import AsyncConsumer
 from app.response_processor import ResponseProcessor
+from app.queue_publisher import QueuePublisher
+from app import settings
 
+logging.basicConfig(level=settings.LOGGING_LEVEL, format=settings.LOGGING_FORMAT)
 logger = wrap_logger(logging.getLogger(__name__))
+
+
+def publish_to_retry_queue(message, count):
+    publisher = QueuePublisher(logger, settings.RABBIT_URLS, settings.RABBIT_DELAY_QUEUE, arguments={
+        'x-message-ttl': settings.QUEUE_RETRY_DELAY_IN_MS,
+        'x-dead-letter-exchange': settings.RABBIT_EXCHANGE,
+        'x-dead-letter-routing-key': settings.RABBIT_QUEUE,
+
+    })
+    return publisher.publish_message(message, headers={'x-delivery-count': count})
+
+
+def get_delivery_count_from_properties(properties):
+    delivery_count = 0
+    if properties.headers and 'x-delivery-count' in properties.headers:
+        delivery_count = properties.headers['x-delivery-count']
+
+    return delivery_count
 
 
 class Consumer(AsyncConsumer):
     def on_message(self, unused_channel, basic_deliver, properties, body):
-        logger.info('Received message', delivery_tag=basic_deliver.delivery_tag, app_id=properties.app_id, body=body)
+        logger.info('Received message', delivery_tag=basic_deliver.delivery_tag, app_id=properties.app_id, body=body.decode("utf-8"))
+
+        delivery_count = get_delivery_count_from_properties(properties)
+        delivery_count += 1
 
         processor = ResponseProcessor(logger)
 
@@ -17,6 +41,16 @@ class Consumer(AsyncConsumer):
 
             if processed_ok:
                 self.acknowledge_message(basic_deliver.delivery_tag, tx_id=processor.tx_id)
+            else:
+                if delivery_count == settings.QUEUE_MAX_MESSAGE_DELIVERIES:
+                    logger.error("Reached maximum number of retries", tx_id=processor.tx_id, delivery_count=delivery_count)
+                    self.reject_message(basic_deliver.delivery_tag, tx_id=processor.tx_id)
+                else:
+                    if publish_to_retry_queue(body, delivery_count):
+                        logger.info("Published to retry queue", tx_id=processor.tx_id, queue=settings.RABBIT_DELAY_QUEUE, delivery_count=delivery_count)
+                        self.reject_message(basic_deliver.delivery_tag, tx_id=processor.tx_id)
+                    else:
+                        logger.error("Failed to publish to retry queue", tx_id=processor.tx_id, queue=settings.RABBIT_DELAY_QUEUE)
 
         except Exception as e:
             logger.error("ResponseProcessor failed", exception=e, tx_id=processor.tx_id)

--- a/app/queue_publisher.py
+++ b/app/queue_publisher.py
@@ -1,0 +1,68 @@
+import pika
+
+
+class QueuePublisher(object):
+
+    DURABLE_QUEUE = True
+
+    def __init__(self, logger, urls, queue, arguments=None):
+        self._logger = logger
+        self._urls = urls
+        self._queue = queue
+        self._arguments = arguments
+        self._connection = None
+        self._channel = None
+
+    def _connect(self):
+        self._logger.debug("Connecting to queue")
+        for url in self._urls:
+            try:
+                self._connection = pika.BlockingConnection(pika.URLParameters(url))
+                self._channel = self._connection.channel()
+                self._channel.queue_declare(queue=self._queue,
+                                            durable=self.DURABLE_QUEUE,
+                                            arguments=self._arguments)
+                self._logger.debug("Connected to queue", url=url)
+                return True
+
+            except pika.exceptions.AMQPConnectionError as e:
+                self._logger.error("Unable to connect to queue", exception=repr(e), url=url)
+                continue
+
+        return False
+
+    def _disconnect(self):
+        try:
+            self._connection.close()
+            self._logger.debug("Disconnected from queue")
+
+        except Exception as e:
+            self._logger.error("Unable to close connection", exception=repr(e))
+
+    def _publish(self, message, content_type=None, headers=None):
+        try:
+            self._channel.basic_publish(exchange='',
+                                        routing_key=self._queue,
+                                        properties=pika.BasicProperties(
+                                            content_type=content_type,
+                                            headers=headers,
+                                            delivery_mode=2
+                                        ),
+                                        body=message)
+            self._logger.debug("Published message")
+            return True
+
+        except Exception as e:
+            self._logger.error("Unable to publish message", exception=repr(e))
+            return False
+
+    def publish_message(self, message, content_type=None, headers=None):
+        self._logger.debug("Sending message")
+        if not self._connect():
+            return False
+
+        if not self._publish(message, headers=headers):
+            return False
+
+        self._disconnect()
+        return True

--- a/app/settings.py
+++ b/app/settings.py
@@ -5,7 +5,7 @@ from requests.packages.urllib3.util.retry import Retry
 from requests.adapters import HTTPAdapter
 
 LOGGING_FORMAT = "%(asctime)s|%(levelname)s: sdx-collect: %(message)s"
-LOGGING_LEVEL = logging.DEBUG
+LOGGING_LEVEL = logging.getLevelName(os.getenv('LOGGING_LEVEL', 'DEBUG'))
 
 APP_ROOT = os.path.dirname(os.path.abspath(__file__))
 APP_TMP = os.path.join(APP_ROOT, 'tmp')
@@ -20,6 +20,10 @@ RECEIPT_USER = os.getenv("RECEIPT_USER", "")
 RECEIPT_PASS = os.getenv("RECEIPT_PASS", "")
 
 RABBIT_QUEUE = os.getenv('RABBITMQ_QUEUE', 'survey')
+RABBIT_DELAY_QUEUE = os.getenv('RABBITMQ_QUEUE', 'survey_delay')
+RABBIT_EXCHANGE = os.getenv('RABBITMQ_EXCHANGE', 'message')
+QUEUE_RETRY_DELAY_IN_MS = 20000
+QUEUE_MAX_MESSAGE_DELIVERIES = 3
 
 RABBIT_URL = 'amqp://{user}:{password}@{hostname}:{port}/{vhost}'.format(
     hostname=os.getenv('RABBITMQ_HOST', 'rabbit'),


### PR DESCRIPTION
**Changes**
Uses a dead letter queue with a ttl on the messages to provide delayed retries functionality. See
http://stackoverflow.com/questions/17014584/how-to-create-a-delayed-queue-in-rabbitmq.
Also uses a 'x-delivery-count' header to keep track of how many times a message has been attempted and limit the number of attempts at re-processing. 

Note that we still don't consider whether an error is retry-able or not - we just naively attempt to re-process a message up to three times. That will need to be done in a future pull request. 

**How to test**
- Run the sdx-compose setup
- Submit a survey and ensure outputs are generated
- Remove the survey_id from a survey and submit
- Check logs or rabbitmq web UI to see messages written to the survey_delay queue and after a 20 second delay moving back to the survey queue (which sdx-collect) then picks up again.
- Verify that 3 attempts are made at processing the message.

**Who can test**
Anyone but @ajmaddaford