### PR TITLE
Add invalid indicator for storage when validation has failed

### DIFF
--- a/app/response_processor.py
+++ b/app/response_processor.py
@@ -29,7 +29,7 @@ class ResponseProcessor:
         # validate
         validate_ok = self.validate_survey(decrypted_json)
         if not validate_ok:
-            return False
+            decrypted_json['invalid'] = True
 
         # store
         store_ok = self.store_survey(decrypted_json)

--- a/tests/test_response_processor.py
+++ b/tests/test_response_processor.py
@@ -24,10 +24,15 @@ class TestResponseProcessor(unittest.TestCase):
         rp = ResponseProcessor(logger)
         rp.decrypt_survey = MagicMock(return_value=(True, valid_json))
         rp.validate_survey = MagicMock(return_value=False)
+        rp.store_survey = MagicMock(return_value=True)
+        rp.skip_receipt = True
         response = rp.process(fake_encrypted)
 
         rp.decrypt_survey.assert_called_with(fake_encrypted)
-        self.assertFalse(response)
+        # When validate returns a failure, the process still actually is meant
+        # to continue, store and return successfully. So even though it's a
+        # "failure" we still expect True
+        self.assertTrue(response)
 
     def test_validate_success_store_failure(self):
         rp = ResponseProcessor(logger)


### PR DESCRIPTION
This allows invalid submissions to be stored in the db rather than logged out.

https://github.com/ONSdigital/sdx-validate/pull/14
https://github.com/ONSdigital/sdx-store/pull/14