### PR TITLE
Update 'requests' -> 2.12.4. Remove requirements from docker file.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,8 @@
-FROM onsdigital/flask-crypto
+FROM onsdigital/flask-crypto-queue
 
 ADD app /app
-ADD requirements.txt /requirements.txt
 ADD startup.sh /startup.sh
 
 RUN mkdir -p /app/logs
-
-RUN pip3 install --no-cache-dir -U -I -r /requirements.txt
 
 ENTRYPOINT ./startup.sh

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests==2.10.0
+requests==2.12.4
 pika==0.10.0
 Jinja2==2.8
 six==1.10.0


### PR DESCRIPTION
Don't need to have requirements call in docker file as dependencies are present in the onsdigital/flask-crypto-queue base image.