### PR TITLE
Feature/log version number on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Unreleased
+  - Add version number to log
 
 ### 1.3.0 2017-02-16
   - Add explicit message ack/nack

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,6 @@
 import logging
 from app import settings
 
+__version__ = "1.3.0"
+
 logging.basicConfig(level=settings.LOGGING_LEVEL, format=settings.LOGGING_FORMAT)

--- a/app/consumer.py
+++ b/app/consumer.py
@@ -80,8 +80,7 @@ class Consumer(AsyncConsumer):
 
 
 def main(args=None):
-    logger.debug("Starting consumer")
-    logger.info("Current version: {}".format(__version__))
+    logger.info("Starting consumer", version=__version__)
 
     if settings.SDX_COLLECT_SECRET is None:
         logger.error("No SDX_COLLECT_SECRET env var supplied")

--- a/app/consumer.py
+++ b/app/consumer.py
@@ -14,6 +14,7 @@ except Exception as e:
     print("Error: ", e, file=sys.stderr)
 
 from structlog import wrap_logger
+from app import __version__
 from app.async_consumer import AsyncConsumer
 from app.response_processor import ResponseProcessor
 from app import settings
@@ -80,6 +81,7 @@ class Consumer(AsyncConsumer):
 
 def main(args=None):
     logger.debug("Starting consumer")
+    logger.info("Current version: {}".format(__version__))
 
     if settings.SDX_COLLECT_SECRET is None:
         logger.error("No SDX_COLLECT_SECRET env var supplied")


### PR DESCRIPTION
Logs the current version number on startup at INFO level. The version number is taken from the `__version__` variable in the `app/__init__.py` file, which will require manual updating when a new release is cut. It is currently configured to the most recent release (1.3.0).

If a `setup.py` file is introduced, the version number should be taken from there to ensure consistency.