### PR TITLE
Feature/log tx id from rabbit header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### Unreleased
   - Pre validate survey ids so that invalid/empty strings aren't routed to census
   - Change logging messages to add the service called or returned from
+  - Get tx_id from message header before decrypting
 
 ### 1.3.1 2017-03-15
   - Add version number to log

--- a/app/consumer.py
+++ b/app/consumer.py
@@ -51,7 +51,9 @@ class Consumer(AsyncConsumer):
         Returns the tx_id for a message from a rabbit queue. The value is
         auto-set by rabbitmq.
         """
-        return properties.headers.get('tx_id')
+        tx_id = properties.headers.get('tx_id')
+        logger.info("Retrieved tx_id from message properties", tx_id=tx_id)
+        return tx_id
 
     def on_message(self, unused_channel, basic_deliver, properties, body):
 

--- a/app/consumer.py
+++ b/app/consumer.py
@@ -81,7 +81,7 @@ class Consumer(AsyncConsumer):
             tx_id=tx_id,
         )
 
-        processor = ResponseProcessor(logger)
+        processor = ResponseProcessor(logger, tx_id=tx_id)
 
         try:
             processor.process(body.decode("utf-8"))
@@ -101,7 +101,8 @@ class Consumer(AsyncConsumer):
             self.reject_message(basic_deliver.delivery_tag, tx_id=tx_id)
             logger.error("Bad message",
                          action="rejected",
-                         exception=e, tx_id=tx_id,
+                         exception=e,
+                         tx_id=tx_id,
                          delivery_count=delivery_count)
 
         except (RetryableError, Exception) as e:

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -1,0 +1,20 @@
+import unittest
+
+from app import consumer
+
+
+class DotDict(dict):
+
+    __getattr__ = dict.get
+
+
+class ConsumerTests(unittest.TestCase):
+
+    def setUp(self):
+        self.consumer = consumer.Consumer()
+        self.props = DotDict({'headers': {'tx_id': 'test'}})
+        self.props_no_txid = DotDict({'headers': {}})
+
+    def test_get_tx_id_from_properties(self):
+        self.assertEqual('test', self.consumer.get_tx_id_from_properties(self.props))
+        self.assertEqual(None, self.consumer.get_tx_id_from_properties(self.props_no_txid))

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -17,4 +17,6 @@ class ConsumerTests(unittest.TestCase):
 
     def test_get_tx_id_from_properties(self):
         self.assertEqual('test', self.consumer.get_tx_id_from_properties(self.props))
-        self.assertEqual(None, self.consumer.get_tx_id_from_properties(self.props_no_txid))
+
+        with self.assertRaises(KeyError):
+            self.consumer.get_tx_id_from_properties(self.props_no_txid)

--- a/tests/test_response_processor.py
+++ b/tests/test_response_processor.py
@@ -51,15 +51,23 @@ class TestResponseProcessor(unittest.TestCase):
 
     def setUp(self):
         self.rp = ResponseProcessor(logger)
+        self.rp_invalid = ResponseProcessor(logger, tx_id='invalid')
 
     def _process(self):
         self.rp.process("NxjsJBSahBXHSbxHBasx")
+
+    def _process_invalid(self):
+        self.rp_invalid.process("NxjsJBSahBXHSbxHBasx")
 
     def test_decrypt(self):
         # <decrypt>
         self.rp.validate_survey = MagicMock()
         self.rp.store_survey = MagicMock()
         self.rp.send_receipt = MagicMock()
+
+        self.rp_invalid.validate_survey = MagicMock()
+        self.rp_invalid.store_survey = MagicMock()
+        self.rp_invalid.send_receipt = MagicMock()
 
         r = Response()
 
@@ -80,6 +88,9 @@ class TestResponseProcessor(unittest.TestCase):
             # 200 - ok
             r.status_code = 200
             self._process()
+
+            with self.assertRaises(BadMessageError):
+                self._process_invalid()
 
     def test_validate(self):
         self.rp.decrypt_survey = MagicMock(return_value=valid_json)


### PR DESCRIPTION
Logs the `tx_id` from a message header's properties rather than from the decrypted response.