### PR TITLE
Feature/feedbackform 2

### DIFF
--- a/app/response_processor.py
+++ b/app/response_processor.py
@@ -70,7 +70,11 @@ class ResponseProcessor:
             decrypted_json['invalid'] = True
 
         self.store_survey(decrypted_json)
-        self.send_receipt(decrypted_json)
+        if decrypted_json["survey_id"] != "feedback":
+            self.send_receipt(decrypted_json)
+        else:
+            self.logger.info("Feedback survey, skipping receipting")
+
         return
 
     def send_receipt(self, decrypted_json):

--- a/app/settings.py
+++ b/app/settings.py
@@ -4,9 +4,8 @@ import requests
 from requests.packages.urllib3.util.retry import Retry
 from requests.adapters import HTTPAdapter
 
-LOGGING_FORMAT = "%(asctime)s.%(msecs)06dZ|%(levelname)s: sdx-collect: %(message)s"
+
 LOGGING_LEVEL = logging.getLevelName(os.getenv('LOGGING_LEVEL', 'DEBUG'))
-LOGGING_DATE_FORMAT = os.getenv('LOGGING_DATE_FORMAT', "%Y-%m-%dT%H:%M:%S")
 
 APP_ROOT = os.path.dirname(os.path.abspath(__file__))
 APP_TMP = os.path.join(APP_ROOT, 'tmp')

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -30,3 +30,28 @@ invalid_decrypted = '''
   "abc": "def"
 }
 '''
+
+feedback_decrypted = '''
+{
+  "tx_id": "0f534ffc-9442-414c-b39f-a756b4adc6cb",
+  "type": "uk.gov.ons.edc.eq:surveyresponse",
+  "version": "0.0.1",
+  "origin": "uk.gov.ons.edc.eq",
+  "survey_id": "feedback",
+  "collection": {
+    "exercise_sid": "hfjdskf",
+    "instrument_id": "0102",
+    "period": "1604"
+  },
+  "metadata": {
+    "user_id": "789473423",
+    "ru_ref": "12345678901A"
+  },
+  "data": {
+    "11": "1/4/2016",
+    "12": "31/10/2016",
+    "20": "1800000",
+    "21": "60000"
+  }
+}
+'''

--- a/tests/test_response_processor.py
+++ b/tests/test_response_processor.py
@@ -10,12 +10,14 @@ from requests import Response
 from structlog import wrap_logger
 
 from app.response_processor import ResponseProcessor
-from tests.test_data import valid_decrypted
+from tests.test_data import feedback_decrypted, valid_decrypted
 from app.helpers.exceptions import DecryptError, RetryableError, BadMessageError
 from app import settings
 
+
 logger = wrap_logger(logging.getLogger(__name__))
 valid_json = json.loads(valid_decrypted)
+feedback = json.loads(feedback_decrypted)
 
 
 class RRMQueue(Exception):
@@ -182,6 +184,15 @@ class TestResponseProcessor(unittest.TestCase):
 
         with self.assertRaises(RetryableError):
             self.rp.send_receipt(invalid_json)
+
+    def test_send_feedback(self):
+        self.rp.decrypt_survey = MagicMock(return_value=feedback)
+        self.rp.validate_survey = MagicMock()
+        self.rp.store_survey = MagicMock()
+
+        self.rp.send_receipt = Mock(side_effect=RRMQueue)
+
+        self._process()
 
     def test_service_name_return_responses(self):
         url = "www.testing.test/responses"


### PR DESCRIPTION
Changed routing so feedback surveys don't receipt.

Feedback survey is currently identified by survey_id="feedback". A proper id for it will have to be agreed.