### PR TITLE
Add more logging around receipts

### DIFF
--- a/app/helpers/exceptions.py
+++ b/app/helpers/exceptions.py
@@ -1,6 +1,6 @@
 class BadMessageError(Exception):
     # A bad message is broken in some way that will never be accepted by
-    # the endpoing and as such should be rejected (it will still be logged
+    # the endpoint and as such should be rejected (it will still be logged
     # and stored so no data is lost)
     pass
 

--- a/app/response_processor.py
+++ b/app/response_processor.py
@@ -95,12 +95,25 @@ class ResponseProcessor:
                               ru_ref=decrypted_json['metadata']['ru_ref'])
             queue_ok = False
         elif decrypted_json.get("survey_id") == "census":
+            self.logger.info(
+                "About to publish receipt to ctp queue",
+                tx_id=decrypted_json['tx_id'],
+            )
             queue_ok = self.ctp_publisher.publish_message(dumps(receipt_json), secret=settings.SDX_COLLECT_SECRET)
         else:
+            self.logger.info(
+                "About to publish receipt to rrm queue",
+                tx_id=decrypted_json['tx_id'],
+            )
             queue_ok = self.rrm_publisher.publish_message(dumps(receipt_json), secret=settings.SDX_COLLECT_SECRET)
 
         if not queue_ok:
             raise RetryableError()
+        else:
+            self.logger.info(
+                "Receipt Published,
+                tx_id=receipt_json['tx_id'],
+            )
 
     def decrypt_survey(self, encrypted_survey):
         self.logger.debug("Decrypting survey")

--- a/app/response_processor.py
+++ b/app/response_processor.py
@@ -111,7 +111,7 @@ class ResponseProcessor:
             raise RetryableError()
         else:
             self.logger.info(
-                "Receipt Published,
+                "Receipt Published",
                 tx_id=receipt_json['tx_id'],
             )
 

--- a/app/response_processor.py
+++ b/app/response_processor.py
@@ -89,15 +89,16 @@ class ResponseProcessor:
             }
         }
 
-        self.logger.info("About to publish receipt into queue")
         if not decrypted_json.get("survey_id"):
             self.logger.error("No survey id",
                               tx_id=decrypted_json['tx_id'],
                               ru_ref=decrypted_json['metadata']['ru_ref'])
             queue_ok = False
         elif decrypted_json.get("survey_id") == "census":
+            self.logger.info("About to publish receipt into ctp queue")
             queue_ok = self.ctp_publisher.publish_message(dumps(receipt_json), secret=settings.SDX_COLLECT_SECRET)
         else:
+            self.logger.info("About to publish receipt into rrm queue")
             queue_ok = self.rrm_publisher.publish_message(dumps(receipt_json), secret=settings.SDX_COLLECT_SECRET)
 
         if not queue_ok:


### PR DESCRIPTION
Before there was very little logging describing which queue was being published too. This commit adds this
and also puts the tx_id as a field for easier searching.