### PR TITLE
Receipt a survey only if the JSON is valid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### Unreleased
   - Change all instances of ADD to COPY in Dockerfile
   - Remove use of SDX_HOME variable in makefile
+  - Only receipt if the JSON data is valid
 
 ### 1.4.1 2017-07-11
   - Fix #180 where message is not quarantined when a DecryptError is raised

--- a/app/response_processor.py
+++ b/app/response_processor.py
@@ -68,12 +68,15 @@ class ResponseProcessor:
             # If the validation fails, the message is to be marked "invalid"
             # and then stored. We don't then want to stop processing at this point.
             decrypted_json['invalid'] = True
-
-        self.store_survey(decrypted_json)
-        if decrypted_json.get("survey_id") != "feedback":
-            self.send_receipt(decrypted_json)
         else:
-            self.logger.info("Feedback survey, skipping receipting")
+            # only send the receipt is the json is valid
+            if decrypted_json.get("survey_id") != "feedback":
+                self.send_receipt(decrypted_json)
+            else:
+                self.logger.info("Feedback survey, skipping receipting")
+        finally:
+            # store the survey regardless
+            self.store_survey(decrypted_json)
 
         return
 
@@ -94,6 +97,7 @@ class ResponseProcessor:
                               tx_id=decrypted_json['tx_id'],
                               ru_ref=decrypted_json['metadata']['ru_ref'])
             queue_ok = False
+
         elif decrypted_json.get("survey_id") == "census":
             self.logger.info("About to publish receipt into ctp queue")
             queue_ok = self.ctp_publisher.publish_message(dumps(receipt_json), secret=settings.SDX_COLLECT_SECRET)

--- a/app/response_processor.py
+++ b/app/response_processor.py
@@ -68,12 +68,14 @@ class ResponseProcessor:
             # If the validation fails, the message is to be marked "invalid"
             # and then stored. We don't then want to stop processing at this point.
             decrypted_json['invalid'] = True
+            self.logger.info("Invalid survey data, skipping receipting", tx_id=self.tx_id)
         else:
             # only send the receipt is the json is valid
             if decrypted_json.get("survey_id") != "feedback":
+                self.logger.info("Receipting survey", tx_id=self.tx_id)
                 self.send_receipt(decrypted_json)
             else:
-                self.logger.info("Feedback survey, skipping receipting")
+                self.logger.info("Feedback survey, skipping receipting", tx_id=self.tx_id)
         finally:
             # store the survey regardless
             self.store_survey(decrypted_json)


### PR DESCRIPTION
## What? and Why?
Only receipt if the Survey data is valid. I believe this is part of the reason we had a message endlessly nacking around the system. The test data was missing a survey id, so validation failed with a 500 which caused collect to error when it attempted to get the survey id. The whole thing then gets repeatably re-attempted. There is an associated sdx-validate change with this.

## Checklist
  - [x] CHANGELOG.md updated? (if required)
