### PR TITLE
Do not process ctp submissions. Log at info the fact that a ctp submission was received

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Unreleased
   - Ensure integrity and version of library dependencies
+  - No longer process CTP submissions
 
 ### 1.5.0 2017-07-25
   - Change all instances of ADD to COPY in Dockerfile

--- a/app/response_processor.py
+++ b/app/response_processor.py
@@ -34,9 +34,6 @@ class ResponseProcessor:
         self.rrm_publisher = PrivatePublisher(
             settings.RABBIT_URLS, settings.RABBIT_RRM_RECEIPT_QUEUE
         )
-        self.ctp_publisher = PrivatePublisher(
-            settings.RABBIT_URLS, settings.RABBIT_CTP_RECEIPT_QUEUE
-        )
 
     def service_name(self, url=None):
         try:
@@ -108,14 +105,8 @@ class ResponseProcessor:
             raise QuarantinableError
 
         elif decrypted_json.get("survey_id") == "census":
-            self.logger.info("About to publish receipt into ctp queue")
-
-            try:
-                self.ctp_publisher.publish_message(dumps(receipt_json),
-                                                   secret=settings.SDX_COLLECT_SECRET)
-            except PublishMessageError as e:
-                self.logger.error("Unsuccesful publish", error=e)
-                raise RetryableError
+            self.logger.info("Ignoring received CTP submission")
+            return None
 
         else:
 

--- a/tests/test_response_processor.py
+++ b/tests/test_response_processor.py
@@ -196,8 +196,10 @@ class TestResponseProcessor(unittest.TestCase):
         # # rrm queue fail census
         census_json = valid_json
         census_json['survey_id'] = 'census'
-        with self.assertRaises(RetryableError):
-            self._process()
+        with self.assertLogs(level='INFO') as cm:
+            self.rp.send_receipt(census_json)
+
+        self.assertIn("Ignoring received CTP submission", cm.output[0])
 
         # rrm publish ok
         json_023 = valid_json
@@ -209,7 +211,6 @@ class TestResponseProcessor(unittest.TestCase):
 
         # Queue types
         self.rp.rrm_publisher.publish_message = Mock(side_effect=RRMQueue)
-        self.rp.ctp_publisher.publish_message = Mock(side_effect=CTPQueue)
 
         with self.assertRaises(RRMQueue):
             self.rp.send_receipt(valid_json)
@@ -217,8 +218,10 @@ class TestResponseProcessor(unittest.TestCase):
         census_json = valid_json
         census_json['survey_id'] = 'census'
 
-        with self.assertRaises(CTPQueue):
-            self.rp.send_receipt(valid_json)
+        with self.assertLogs(level='INFO') as cm:
+            self.rp.send_receipt(census_json)
+
+        self.assertIn("Ignoring received CTP submission", cm.output[0])
 
         invalid_json = copy.deepcopy(valid_json)
         invalid_json['survey_id'] = None


### PR DESCRIPTION
## What? and Why?
This pull request alters the process for dealing with a CTP submission to collect. Instead of receipting, a CTP submission will now cause the logline "Ignoring received CTP submission" to be emitted, and no further processing of the submission will take place.

  - [x] CHANGELOG.md updated? (if required)
