### PR TITLE
Retry handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Unreleased
+  - Added RetryableError to remote_call so that HTTP errors give rise to rabbit NAKS and hence retry
 
 ### 3.1.0 2017-10-16
   - Hardcode unchanging variables in settings.py to make configuration management simpler

--- a/app/response_processor.py
+++ b/app/response_processor.py
@@ -199,6 +199,10 @@ class ResponseProcessor:
 
         except MaxRetryError:
             self.logger.error("Max retries exceeded (5)", request_url=request_url)
+            raise RetryableError
+        except ConnectionError:
+            self.logger.error("Connection error occurred. Retrying")
+            raise RetryableError
 
     def response_ok(self, res):
         request_url = res.url


### PR DESCRIPTION
## What? and Why?
Previous code could hang on http error after urllib retries with heartbeat still working only corrected by a restart.
Now http errors will raise a RetryableError leading to a NAK and retry . 

## Checklist
  -  CHANGELOG.md updated 
