### PR TITLE
Updating cloud foundry python

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.6.1
+python-3.6.3


### PR DESCRIPTION
## What? and Why?
Python 3.6.1 no longer exists in cloud foundry

## Checklist
  - [ ] CHANGELOG.md updated? (if required)
