### PR TITLE
Release 3.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ### Unreleased
+
+### 3.6.0 2018-06-20
   - Support LMS test 1 by skipping downstream
 
 ### 3.5.0 2018-03-06

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,7 +2,7 @@ import requests
 from requests.packages.urllib3.util.retry import Retry
 from requests.adapters import HTTPAdapter
 
-__version__ = "3.5.0"
+__version__ = "3.6.0"
 
 # Configure the number of retries attempted before failing call
 session = requests.Session()


### PR DESCRIPTION
## What? and Why?
- Support LMS test 1 by skipping downstream

## Checklist
  - [ ] CHANGELOG.md updated? (if required)
