### PR TITLE
Remove 2nd host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Unreleased
+  - Remove second rabbit host.
 
 ### 3.6.0 2018-06-20
   - Support LMS test 1 by skipping downstream

--- a/app/settings.py
+++ b/app/settings.py
@@ -32,12 +32,11 @@ def parse_vcap_services():
     rabbit_config = parsed_vcap_services.get('rabbitmq')
 
     rabbit_url = rabbit_config[0].get('credentials').get('uri') + HEARTBEAT_INTERVAL
-    rabbit_url2 = rabbit_config[1].get('credentials').get('uri') + HEARTBEAT_INTERVAL if len(rabbit_config) > 1 else rabbit_url
-    return rabbit_url, rabbit_url2
+    return rabbit_url
 
 
 if os.getenv("CF_DEPLOYMENT", False):
-    RABBIT_URL, RABBIT_URL2 = parse_vcap_services()
+    RABBIT_URL = parse_vcap_services()
 else:
     RABBIT_URL = 'amqp://{user}:{password}@{hostname}:{port}/{vhost}'.format(
         hostname=os.getenv('RABBITMQ_HOST', 'rabbit'),

--- a/app/settings.py
+++ b/app/settings.py
@@ -47,14 +47,6 @@ else:
         vhost=os.getenv('RABBITMQ_DEFAULT_VHOST', '%2f')
     ) + HEARTBEAT_INTERVAL
 
-    RABBIT_URL2 = 'amqp://{user}:{password}@{hostname}:{port}/{vhost}'.format(
-        hostname=os.getenv('RABBITMQ_HOST2', 'rabbit'),
-        port=os.getenv('RABBITMQ_PORT2', 5672),
-        user=os.getenv('RABBITMQ_DEFAULT_USER', 'rabbit'),
-        password=os.getenv('RABBITMQ_DEFAULT_PASS', 'rabbit'),
-        vhost=os.getenv('RABBITMQ_DEFAULT_VHOST', '%2f')
-    ) + HEARTBEAT_INTERVAL
-
-RABBIT_URLS = [RABBIT_URL, RABBIT_URL2]
+RABBIT_URLS = [RABBIT_URL]
 
 RABBIT_SURVEY_QUEUE = 'sdx-survey-notification-durable'

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -13,11 +13,9 @@ class TestSettings(unittest.TestCase):
             os.environ['VCAP_SERVICES'] = fp.read()
 
     def test_cf_settings(self):
-        rabbit_url1, rabbit_url2 = settings.parse_vcap_services()
+        rabbit_url1 = settings.parse_vcap_services()
 
         self.assertEqual("amqp://user:password@168.0.0.1:5672/example_vhost?heartbeat_interval=5", rabbit_url1)
-        self.assertEqual("amqp://user:password@168.0.0.1:5672/example_vhost?heartbeat_interval=5", rabbit_url2)
 
     def test_heartbeat(self):
         self.assertEqual("amqp://rabbit:rabbit@rabbit:5672/%2f?heartbeat_interval=5", settings.RABBIT_URL)
-        self.assertEqual("amqp://rabbit:rabbit@rabbit:5672/%2f?heartbeat_interval=5", settings.RABBIT_URL2)


### PR DESCRIPTION
## What? and Why?
In moving to AWS corp, there aren't 2 rabbit URLs to hit, there is 1 url that load balances between rabbit clusters.

## Checklist
  - [x] CHANGELOG.md updated? (if required)
