### PR TITLE
Copy rsi data and send to dap as Dtrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Unreleased
+  - RSI submissions (023) will have a duplicate Dtrades (281) submission sent to DAP
   - Update packages to fix security issue
 
 ### 3.11.0 2019-02-08

--- a/app/response_processor.py
+++ b/app/response_processor.py
@@ -300,7 +300,7 @@ class ResponseProcessor:
             self.logger.info("Publishing data to dap queue")
             self.dap.publish_message(
                 dumps(message),
-                headers={'tx_id': self.tx_id})
+                headers={'tx_id': decrypted_json['tx_id']})
         except PublishMessageError:
             self.logger.exception("Failed to publish to dap queue")
             raise RetryableError


### PR DESCRIPTION
## What? and Why?
https://trello.com/c/fRBkb2xA/753-copy-rsi-data-and-send-to-dap-as-a-dtrades-submission
RSI submissions are required to go to DAP as a Dtrades submission.  This PR does the duplication, changes the required data and puts it onto the dap queue.

## How to test
 - Put through a 023.xxxx submission in sdx-console.  
 - Check that in the FTP server there is a 023 submission with the tx_id of the original submission.
 - Check in the rabbit manager (http://localhost:15672) in the dap queue that there is a submission with 281 as the survey id and a different tx_id to the original submission (but the same data, which will be checked in the next step)
 - Finally, check in the sdx-store (can do it via the api or a db app), that the data from the 2 submissions is identical apart from the tx_id and the survey id

## Checklist
  - [x] CHANGELOG.md updated? (if required)
