### PR TITLE
Send rsi submissions to dap as well as downstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Unreleased
+  - Set RSI to go to DAP
 
 ### 3.11.1 2019-02-19
   - Update packages to fix security issue

--- a/app/response_processor.py
+++ b/app/response_processor.py
@@ -151,7 +151,7 @@ class ResponseProcessor:
         if self._is_feedback_survey(decrypted_json):
             self.logger.info("Feedback survey, skipping sending to DAP")
             return False
-        if decrypted_json.get("survey_id") in ("lms", "281", "census"):  # LMS, D-Trades, census
+        if decrypted_json.get("survey_id") in ["023", "281", "lms", "census"]:  # RSI, Dtrades
             self.logger.info("Sending to DAP", survey_id=decrypted_json.get("survey_id"))
             return True
         return False


### PR DESCRIPTION
## What? and Why?
https://trello.com/c/fRBkb2xA/753-copy-rsi-data-and-send-to-dap-as-a-dtrades-submission-2

RSI submissions need to go to DAP as well as to common software.

## How to test
Submit an RSI survey via console.  Make sure that it ends up in both the FTP folder and ends up on the DAP queue in rabbit (you can see it via the management console)

## Checklist
  - [ ] CHANGELOG.md updated? (if required)
