### PR TITLE
Investigate extra sdx decrypt lines after submissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Unreleased
+  - Fix bug where tx_id from previous submission was bound to the logger before decryption was done
 
 ### 3.12.0 2019-03-25
   - Set RSI to go to DAP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Unreleased
   - Fix bug where tx_id from previous submission was bound to the logger before decryption was done
+  - Update urllib3 to fix security issue
 
 ### 3.12.0 2019-03-25
   - Set RSI to go to DAP

--- a/app/response_processor.py
+++ b/app/response_processor.py
@@ -53,8 +53,7 @@ class ResponseProcessor:
         decrypted_json = self.decrypt_survey(msg)
 
         metadata = decrypted_json.get('metadata', {})
-        self.logger = self.logger.bind(
-            user_id=metadata.get('user_id'), ru_ref=metadata.get('ru_ref'))
+        self.logger = self.logger.bind(user_id=metadata.get('user_id'), ru_ref=metadata.get('ru_ref'))
 
         if not tx_id:
             self.tx_id = decrypted_json.get('tx_id')
@@ -84,7 +83,9 @@ class ResponseProcessor:
         if valid and self._requires_dap_processing(decrypted_json):
             self.send_to_dap_queue(decrypted_json)
 
-        self.logger.unbind("user_id", "ru_ref", "tx_id")
+        # If we don't unbind these fields, their current value will be retained for the next
+        # submission.  This leads to incorrect values being logged out in the bound fields.
+        self.logger = self.logger.unbind("user_id", "ru_ref", "tx_id")
 
     def decrypt_survey(self, encrypted_survey):
         self.logger.info("Decrypting survey")

--- a/app/response_processor.py
+++ b/app/response_processor.py
@@ -47,6 +47,9 @@ class ResponseProcessor:
             self.logger.exception("No valid service name")
 
     def process(self, msg, tx_id=None):
+        # Bind the tx_id from the rabbit message header as we don't have access to the one in the survey yet.
+        self.logger = self.logger.bind(tx_id=tx_id)
+
         decrypted_json = self.decrypt_survey(msg)
 
         metadata = decrypted_json.get('metadata', {})
@@ -63,8 +66,6 @@ class ResponseProcessor:
             raise QuarantinableError
         else:
             self.tx_id = tx_id
-
-        self.logger = self.logger.bind(tx_id=self.tx_id)
 
         valid = self.validate_survey(decrypted_json)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,9 +22,9 @@ six==1.12.0 \
 requests==2.21.0 \
     --hash=sha256:502a824f31acdacb3a35b6690b5fbf0bc41d63a24a45c4004352b0242707598e \
     --hash=sha256:7bf2a778576d825600030a110f3c0e3e8edc51dfaafe1c146e39a2027784957b
-urllib3==1.24.1 \
-    --hash=sha256:61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39 \
-    --hash=sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22
+urllib3==1.24.2 \
+    --hash=sha256:4c291ca23bbb55c76518905869ef34bdd5f0e46af7afe6861e8375643ffee1a0 \
+    --hash=sha256:9a247273df709c4fedb38c711e44292304f73f39ab01beda9f6b9fc375669ac3
 chardet==3.0.4 \
     --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691 \
     --hash=sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae


### PR DESCRIPTION
## What? and Why?
There was a bug where every submission after the first would have the previous submissions tx_id in the logs between the start and after the decryption.  After the decryption, the correct one became bound.  This fixes that issue.

Additionally updates urllib3 to fix a security vulnerability.

## How to test
- Check out master
- Put through 2 submissions.  You'll notice on the second submission there are references to the first submissions tx_id, user_id and ru_ref in the first few lines (around the time being decrypted)
- Check this branch out
- Put through 2 more submissions and notice that the incorrect data is not there anymore.

## Checklist
  - [x] CHANGELOG.md updated? (if required)
