### PR TITLE
995 revert to default heartbeat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Unreleased
+  - Reverted to default heartbeat
   - Remove python 3.4 and 3.5 from travis builds
   - Add python 3.7 to travis builds
   - Upgrade packages, including sdc-rabbit, tornado and pika to allow upgrade to python 3.7

--- a/app/settings.py
+++ b/app/settings.py
@@ -18,7 +18,6 @@ RABBIT_QUARANTINE_QUEUE = os.getenv('RABBIT_QUARANTINE_QUEUE', 'survey_quarantin
 RABBIT_EXCHANGE = 'message'
 
 RABBIT_RRM_RECEIPT_QUEUE = 'rrm_receipt'
-HEARTBEAT_INTERVAL = "?heartbeat=5"
 
 DAP_SOURCE_NAME = os.getenv("DAP_SOURCE_NAME", "sdx_development")
 
@@ -33,7 +32,7 @@ def parse_vcap_services():
     parsed_vcap_services = json.loads(vcap_services)
     rabbit_config = parsed_vcap_services.get('rabbitmq')
 
-    rabbit_url = rabbit_config[0].get('credentials').get('uri') + HEARTBEAT_INTERVAL
+    rabbit_url = rabbit_config[0].get('credentials').get('uri')
     return rabbit_url
 
 
@@ -46,7 +45,7 @@ else:
         user=os.getenv('RABBITMQ_DEFAULT_USER', 'rabbit'),
         password=os.getenv('RABBITMQ_DEFAULT_PASS', 'rabbit'),
         vhost=os.getenv('RABBITMQ_DEFAULT_VHOST', '%2f')
-    ) + HEARTBEAT_INTERVAL
+    )
 
 RABBIT_URLS = [RABBIT_URL]
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -15,7 +15,7 @@ class TestSettings(unittest.TestCase):
     def test_cf_settings(self):
         rabbit_url1 = settings.parse_vcap_services()
 
-        self.assertEqual("amqp://user:password@168.0.0.1:5672/example_vhost?heartbeat=5", rabbit_url1)
+        self.assertEqual("amqp://user:password@168.0.0.1:5672/example_vhost", rabbit_url1)
 
     def test_heartbeat(self):
-        self.assertEqual("amqp://rabbit:rabbit@rabbit:5672/%2f?heartbeat=5", settings.RABBIT_URL)
+        self.assertEqual("amqp://rabbit:rabbit@rabbit:5672/%2f", settings.RABBIT_URL)


### PR DESCRIPTION
## What? and Why?
> Heartbeat was occurring too frequently leading to noise in the logs . By removing the override it now heartbeats every 30 seconds which is agreed to be sufficient

## Checklist
  - [x ] CHANGELOG.md updated? (if required)
