### PR TITLE
Strip null character

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Unreleased
+  - Quarantine submissions and feedback if they have null characters (`\u0000`) in the text
 
 ### 3.16.1 2019-11-08
   - Add python 3.8 to travis builds

--- a/app/response_processor.py
+++ b/app/response_processor.py
@@ -294,6 +294,9 @@ class ResponseProcessor:
             return
 
         elif 400 <= res.status_code < 500:
+            if res.json().get('contains_null_character'):
+                logger.error("Null character found in payload, quarantining submission")
+                raise QuarantinableError
             res_logger.error("Returned from service", response="client error", service=service)
             raise ClientError
 


### PR DESCRIPTION
## What? and Why?
If a submission had a null character in it, it would fail to save to store, get put back on the queue, then loop infinitely.
This PR makes it so that if there is a null character in a submission data (feedback and 1.0.0) then it gets quarantined

## Checklist
  - [x] CHANGELOG.md updated? (if required)
