### PR TITLE
Better handle submissions with invalid characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ### Unreleased
+  - Better handle submissions if they have invalid characters.  The fix implemented in 3.17.0 didn't
+  work as expected.
 
 ### 3.17.0 2020-01-27
   - Quarantine submissions and feedback if they have null characters (`\u0000`) in the text

--- a/app/response_processor.py
+++ b/app/response_processor.py
@@ -114,6 +114,7 @@ class ResponseProcessor:
     def store_survey(self, decrypted_json):
         self.logger.info("Storing survey")
         response = self.remote_call(settings.SDX_RESPONSES_URL, json=decrypted_json)
+
         try:
             self.response_ok(response)
         except ClientError:
@@ -286,16 +287,15 @@ class ResponseProcessor:
 
         service = self.service_name(request_url)
 
-        res_logger = self.logger
-        res_logger.bind(request_url=res.url, status=res.status_code)
+        res_logger = self.logger.bind(request_url=res.url, status=res.status_code)
 
         if res.status_code == 200 or res.status_code == 201:
             res_logger.info("Returned from service", response="ok", service=service)
             return
 
         elif 400 <= res.status_code < 500:
-            if res.json().get('contains_null_character'):
-                logger.error("Null character found in payload, quarantining submission")
+            if res.json().get('contains_invalid_character'):
+                logger.error("Invalid character found in payload, quarantining submission")
                 raise QuarantinableError
             res_logger.error("Returned from service", response="client error", service=service)
             raise ClientError

--- a/tests/test_response_processor.py
+++ b/tests/test_response_processor.py
@@ -369,18 +369,18 @@ class TestResponseProcessor(unittest.TestCase):
 
     @responses.activate
     def test_null_character_raises_quarantine_error(self):
-        url = "http://sdx-validate:5000/validate"
-        response_json = {"contains_null_character": True,
-                         "valid": False,
-                         "status": 400,
-                         "message": "Null character found in submission",
-                         "uri": "http://sdx-validate:5000/validate"}
+        url = "http://sdx-store:5000/responses"
+        response_json = {"contains_invalid_character": True,
+                         "status_code": 400,
+                         "message": "Invalid characters in payload",
+                         "url": "http://sdx-store:5000/responses"}
 
         responses.add(responses.POST, url,
                       json=response_json,
                       status=400)
 
         self.rp.decrypt_survey = MagicMock(return_value=valid_json)
+        self.rp.validate_survey = MagicMock(return_value=True)
         with self.assertRaises(QuarantinableError):
             self._process()
 


### PR DESCRIPTION
## What? and Why?
There was a fix put in place to handle submissions with invalid characters.  This didn't work, so another better fix has been put in place.

## How to test

- Spin up the sdx services in sdx-compose with sdx-validate, sdx-collect and sdx-store on the handle-invalid-chars branch.
- In sdx-console, submit a 009.0201, but not before changing 146h to include the string \u0000 (this can be anywhere in the string)
- Submit this, it should be put in the quarantine queue (view in management console on localhost:15672) and there should be some error logging to reflect this in store and collect

## Checklist
  - [x] CHANGELOG.md updated? (if required)
